### PR TITLE
chore: Move test deps to own Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,28 +8,14 @@ AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
 NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
 PencilFFTs = "4a48f351-57a6-4416-9ec4-c37015456aae"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AbstractFFTs = "0.5, 1.0"
-Documenter = "0.25"
 FFTW = "1.2"
 MPI = "0.16, 0.17"
-NBInclude = "2.2"
 NPZ = "0.4"
 PencilFFTs = "0.12"
 julia = "1"
-
-[extras]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Documenter", "SafeTestsets", "Test"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
+NBInclude = "0db19996-df87-5ea3-a455-e3a50d440464"
+NPZ = "15e1cf62-19b3-5cfa-8e77-841668bca605"
+PencilFFTs = "4a48f351-57a6-4416-9ec4-c37015456aae"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"


### PR DESCRIPTION
There are a few dependencies that are only needed for tests, not the
library.  Move them to their own Project.toml.