### PR TITLE
opt: Remove anonymous a(t) from docs and benches

### DIFF
--- a/benchmarks/time_step.jl
+++ b/benchmarks/time_step.jl
@@ -21,8 +21,8 @@ for (label, grids) in [("Grids", Grids(1.0, n)), ("PencilGrids", PencilGrids(1.0
     suite[label]["phi_whole_step"] = @benchmarkable phi_whole_step!($Δt, $grids)
 
 
-    suite[label]["take_steps"] = @benchmarkable take_steps!($grids, $1.0, $Δt, 1, $(OutputConfig("output", 1:2)), $(t -> 1))
-    suite[label]["take_steps 10"] = @benchmarkable take_steps!($grids, $1.0, $Δt, 10, $(OutputConfig("output", 1:2)), $(t -> 1))
+    suite[label]["take_steps"] = @benchmarkable take_steps!($grids, $1.0, $Δt, 1, $(OutputConfig("output", 1:2)), $(Config.constant_scale_factor))
+    suite[label]["take_steps 10"] = @benchmarkable take_steps!($grids, $1.0, $Δt, 10, $(OutputConfig("output", 1:2)), $(Config.constant_scale_factor))
 
 end
 

--- a/benchmarks/time_step/time_step.jl
+++ b/benchmarks/time_step/time_step.jl
@@ -17,14 +17,14 @@ n_steps = 10
 
 grids = Grids(1.0, resol)
 
-# b = @benchmark take_steps!($grids, $1.0, $Δt, 10, $(OutputConfig("output", 1:2)), $(t -> 1))
+# b = @benchmark take_steps!($grids, $1.0, $Δt, 10, $(OutputConfig("output", 1:2)), $(Config.constant_scale_factor))
 # time_mean = mean(b.times / 1e9 / n_steps)
 
 # Run once to ensure function is precompiled
-take_steps!(grids, 1.0, Δt, n_steps, OutputConfig("output", 1:2), t -> 1)
+take_steps!(grids, 1.0, Δt, n_steps, OutputConfig("output", 1:2), Config.constant_scale_factor)
 
 # Collect data
-res = @timed take_steps!(grids, 1.0, Δt, n_steps, OutputConfig("output", 1:2), t -> 1)
+res = @timed take_steps!(grids, 1.0, Δt, n_steps, OutputConfig("output", 1:2), Config.constant_scale_factor)
 
 time_mean = mean(res[2] / n_steps)
 

--- a/examples/2d.ipynb
+++ b/examples/2d.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "options = Config.SimulationConfig(10, t->1);"
+    "options = Config.SimulationConfig(10);"
    ]
   },
   {

--- a/examples/mpi/soliton_velocity.jl
+++ b/examples/mpi/soliton_velocity.jl
@@ -14,7 +14,7 @@ num_snapshots = 20
 output_times = LinRange(0, 5, num_snapshots)
 
 output_config = OutputConfig(output_dir, output_times; box=true, slice=false)
-options = Config.SimulationConfig(10, t->1)
+options = Config.SimulationConfig(10)
 
 mass = 10
 position0 = [-4, 0, 0]

--- a/examples/soliton_velocity.jl
+++ b/examples/soliton_velocity.jl
@@ -11,7 +11,7 @@ num_snapshots = 20
 output_times = LinRange(0, 5, num_snapshots)
 
 output_config = OutputConfig(output_dir, output_times; box=true, slice=false)
-options = Config.SimulationConfig(10, t->1)
+options = Config.SimulationConfig(10)
 
 mass = 10
 position0 = [-4, 0, 0]

--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -10,7 +10,8 @@ using FFTW
 
 export simulate
 export Grids, PencilGrids
-export Config, OutputConfig
+export Config, constant_scale_factor
+export OutputConfig
 
 const PHASE_GRAD_LIMIT = π / 4
 
@@ -69,9 +70,9 @@ Take `n` steps with time step `Δt`
 # Examples
 
 ```jldoctest
-julia> using UltraDark: take_steps!, Grids, OutputConfig
+julia> using UltraDark: take_steps!, Grids, OutputConfig, Config
 
-julia> take_steps!(Grids(1.0, 16), 0, 0.5, 10, OutputConfig(mktempdir(), []), t->1, nothing)
+julia> take_steps!(Grids(1.0, 16), 0, 0.5, 10, OutputConfig(mktempdir(), []), Config.constant_scale_factor, nothing)
 5.0
 
 ```

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,9 +1,19 @@
 module Config
 
+export SimulationConfig, constant_scale_factor
+
 struct SimulationConfig
     time_step_update_period::UInt8
     "function defining a(t)"
     a
+end
+
+function constant_scale_factor(t)
+    1.0
+end
+
+function SimulationConfig(time_step_update_period)
+    SimulationConfig(time_step_update_period, constant_scale_factor)
 end
 
 end # module

--- a/test/evolution.jl
+++ b/test/evolution.jl
@@ -23,7 +23,7 @@ for grid_type in [Grids, PencilGrids]
     @testset "Take n steps, $grid_type" begin
         grids = grid_type(1.0, 16)
         output_config = OutputConfig(mktempdir(), [])
-        @test UltraDark.take_steps!(grids, 0, 1, 10, output_config, t -> 1, nothing) == 10.0
+        @test UltraDark.take_steps!(grids, 0, 1, 10, output_config, Config.constant_scale_factor, nothing) == 10.0
     end
 end
 
@@ -41,7 +41,7 @@ for grid_type in [Grids, PencilGrids]
         grids.Φx .= grids.rfft_plan \ grids.Φk
 
         output_config = OutputConfig(mktempdir(), [])
-        options = UltraDark.Config.SimulationConfig(10, t->1)
+        options = UltraDark.Config.SimulationConfig(10)
         @test UltraDark.evolve_to!(t_begin, t_end, grids, output_config, options) ≈ t_end
     end
 end

--- a/test/phase_gradient.jl
+++ b/test/phase_gradient.jl
@@ -82,7 +82,7 @@ end
 
     grids_orig = deepcopy(grids)
 
-    options = UltraDark.Config.SimulationConfig(10, t->1)
+    options = UltraDark.Config.SimulationConfig(10)
     output_config = OutputConfig(mktempdir(), [1, 2])
 
     @test_throws "Phase gradient is too large to start" simulate(grids, options, output_config)

--- a/test/sims/full.jl
+++ b/test/sims/full.jl
@@ -9,7 +9,7 @@ output_dir = "output"
 output_times = 0.0:0.002:0.01
 
 output_config = OutputConfig(output_dir, output_times; box=false)
-options = Config.SimulationConfig(10, t->1)
+options = Config.SimulationConfig(10)
 
 for grid_type in [Grids, PencilGrids]
     grids = grid_type(1.0, 16)

--- a/test/sims/soliton_static.jl
+++ b/test/sims/soliton_static.jl
@@ -16,7 +16,7 @@ for grid_type in [Grids, PencilGrids]
     output_times = [0, 1]
 
     output_config = OutputConfig(this_output_dir, output_times; box=true, slice=false)
-    options = Config.SimulationConfig(10, t->1)
+    options = Config.SimulationConfig(10)
 
     grids = grid_type(10.0, resol)
 


### PR DESCRIPTION
Using at anonymous function for the scale factor causes a large number
of allocations, due to repeated compilation in a loop.