### PR TITLE
opt: Fix types

### DIFF
--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -22,19 +22,19 @@ include("time_step.jl")
 include("output.jl")
 include("config.jl")
 
-function psi_half_step!(Δt::Real, grids, constants)
+function psi_half_step!(Δt, grids, constants)
     @inbounds @threads for i in eachindex(grids.ψx)
         grids.ψx[i] *= exp(- im * Δt / 2 * grids.Φx[i])
     end
 end
 
-function psi_whole_step!(Δt::Real, grids, constants)
+function psi_whole_step!(Δt, grids, constants)
     @inbounds @threads for i in eachindex(grids.ψx)
         grids.ψx[i] *= exp(- im * Δt / 1 * grids.Φx[i])
     end
 end
 
-function phi_whole_step!(Δt::Real, grids, constants; a::Real=1.0)
+function phi_whole_step!(Δt, grids, constants; a=1.0)
     # TODO: not all part of Φ update
 
     mul!(grids.ψk, grids.fft_plan, grids.ψx)
@@ -79,7 +79,7 @@ julia> take_steps!(Grids(1.0, 16), 0, 0.5, 10, OutputConfig(mktempdir(), []), Co
 """
 function take_steps!(grids, t_start, Δt, n, output_config, a, constants)
 
-    t = t_start
+    t::Float64 = t_start
 
     half_step = true
 

--- a/src/output.jl
+++ b/src/output.jl
@@ -2,9 +2,9 @@ import NPZ
 
 struct OutputConfig
     "where to write output"
-    directory
+    directory::String
     "times at which to output"
-    output_times::Array{Real}
+    output_times::Array{Float64}
 
     "whether to output boxes"
     box::Bool

--- a/src/phase_diff.jl
+++ b/src/phase_diff.jl
@@ -7,7 +7,7 @@ Returns an array of size `(size(field)[1], size(field)[2], size(field)[2])`
 containing gradients in direction `dir`.
 """
 function phase_diff(field, dir)
-    out = similar(field, Real)
+    out = similar(field, Float64)
 
     out .= angle.(circshift(field, dir) ./  field)
 
@@ -23,7 +23,7 @@ Returns an array of size `(size(field)[1], size(field)[2], size(field)[2])`
 containing gradients in direction `dir`.
 """
 function phase_diff(field::PencilArray, dir)
-    out = similar(field, Real)
+    out = similar(field, Float64)
 
     # TODO diff at boundaries
     out .= 0
@@ -42,7 +42,7 @@ to be anomalous.
 """
 function max_normed_phase_grad(grids)
     DENSITY_THRESHOLD = 1e-6
-    tmp = similar(grids.ψx, Real)
+    tmp = similar(grids.ψx, Float64)
     n = ndims(tmp)
 
     max_grads = zeros(n)

--- a/src/time_step.jl
+++ b/src/time_step.jl
@@ -1,5 +1,5 @@
 """
-    actual_time_step(max_timestep::Real, time_interval::Real, n::Integer)
+    actual_time_step(max_timestep, time_interval, n::Integer)
 
 Actual size and number of time steps that should be taken if the maximum 
 is `max_timestep`, no more than `n` steps should be taken, and they should
@@ -14,7 +14,7 @@ julia> actual_time_step(0.11, 1, 20)
 (0.1, 10)
 ```
 """
-function actual_time_step(max_timestep, time_interval, n)::Tuple{Real, Integer}
+function actual_time_step(max_timestep, time_interval, n)::Tuple{Float64, Integer}
     if max_timestep * n > time_interval
         num_steps = ceil(time_interval / max_timestep)
         time_interval / num_steps, num_steps


### PR DESCRIPTION
Add concrete types in some places and remove abstract types in others.
This takes evolve_to! from millions of allocations to only ~200.