### PR TITLE
feat: Allow user to specify summary

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"

--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -2,7 +2,6 @@ module UltraDark
 
 using Base.Threads: @threads
 using LinearAlgebra
-using Statistics
 using AbstractFFTs: fftfreq, rfftfreq
 using PencilFFTs, MPI
 
@@ -10,7 +9,7 @@ using FFTW
 
 export simulate
 export Grids, PencilGrids
-export Config, constant_scale_factor
+export Config, SimulationConfig, constant_scale_factor
 export OutputConfig
 
 const PHASE_GRAD_LIMIT = π / 4
@@ -21,6 +20,10 @@ include("phase_diff.jl")
 include("time_step.jl")
 include("output.jl")
 include("config.jl")
+
+import .Output: OutputConfig
+import .Output: output_summary_row, output_summary_header, output_grids
+import .Config: SimulationConfig, constant_scale_factor
 
 function psi_half_step!(Δt, grids, constants)
     @inbounds @threads for i in eachindex(grids.ψx)


### PR DESCRIPTION
Allow the user to specify what is written in `summary.csv`.
By default, just the wall time, simulation time, time step and scale
factor.

Technically a breaking change since the max and rms density contrast
aren't output anymore.