### PR TITLE
fix: Indexing errors in MPI example

### DIFF
--- a/examples/init_soliton.jl
+++ b/examples/init_soliton.jl
@@ -9,10 +9,12 @@ function add_soliton(grids, mass, position, velocity, phase, t0)
     alpha = (mass / 3.883)^2
     beta = 2.454
 
-    if typeof(grids) == PencilGrids
+    if typeof(grids) <: PencilGrids
         ψ_glob = global_view(grids.ψx)
-    else
+    elseif typeof(grids) <: Grids
         ψ_glob = grids.ψx
+    else
+        throw("Unrecognised grids type")
     end
 
     for I in CartesianIndices(ψ_glob)


### PR DESCRIPTION
The soliton initialisation script has

```
if typeof(grids) == PencilGrids
```

This is useless as it does not match on the type parameters, which
may depend on the pencil decomposition and so are unknown in general.
Instead one should use the subtype operator.

```
if typeof(grids) <: PencilGrids
```