### PR TITLE
fix: Remove trailing comma from summary.csv

### DIFF
--- a/src/output.jl
+++ b/src/output.jl
@@ -148,9 +148,9 @@ function output_summary_header(output_config)
 end
 
 function generate_summary_row(summary)::String
-    line = ""
-    for i in 1:nfields(summary)
-        line = line * "$(getfield(summary, i)),"
+    line = "$(getfield(summary, 1))"
+    for i in 2:nfields(summary)
+        line = line * ",$(getfield(summary, i))"
     end
     line = line * "\n"
 end


### PR DESCRIPTION
Remove the trailing commas from summary.csv.  This allows CSV.jl to
parse the summary files without warnings.