### PR TITLE
fix: export correct summary types

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,11 @@ doctest(UltraDark)
     include("grids.jl")
 end
 
-@safetestset "output.jl" begin
+@safetestset "grid outputs" begin
+    include("output.jl")
+end
+
+@safetestset "summary ouputs" begin
     include("output.jl")
 end
 

--- a/test/summary.jl
+++ b/test/summary.jl
@@ -1,0 +1,8 @@
+using Test
+using UltraDark: Grids, PencilGrids, output_grids, OutputConfig
+
+for grid_type in [Grids, PencilGrids]
+    for stat in [SummaryStatistics, SummaryStatisticsMeanMaxRms]
+        @test stat(grid_type())
+    end
+end


### PR DESCRIPTION
One of the summary statistics exported from output.jl was named
incorrectly.  Both should be exported from the module as a whole.