### PR TITLE
refactor: Define type AbstractGrids

### DIFF
--- a/src/grids.jl
+++ b/src/grids.jl
@@ -1,4 +1,12 @@
 """
+    AbstractGrids
+
+Abstract type for grids containing simulation data
+"""
+
+abstract type AbstractGrids end
+
+"""
 struct containing grids used in a simulation
 
 # Examples
@@ -15,7 +23,7 @@ julia> Grids(len, resol);
 
 ```
 """
-struct Grids
+struct Grids <: AbstractGrids
     "Array of x positions"
     x::Array{Float64,3}
     "Array of y positions"

--- a/src/pencil_grids.jl
+++ b/src/pencil_grids.jl
@@ -15,7 +15,7 @@ julia> PencilGrids(len, resol);
 
 ```
 """
-struct PencilGrids{K, RX, RK, CX, CK, FFT, RFFT, M}
+struct PencilGrids{K, RX, RK, CX, CK, FFT, RFFT, M} <: AbstractGrids
     "Array of x positions"
     x::Array{Float64,3}
     "Array of y positions"


### PR DESCRIPTION
Define an abstract type `AbstractGrids`.  This is a supertype for other
grids types, allowing dispatch on them more elegantly than dispatch on
`Union{Grids,PencilGrids}`.