### PR TITLE
test: Test summaries on PencilGrids too

### DIFF
--- a/test/summary.jl
+++ b/test/summary.jl
@@ -1,22 +1,38 @@
 using Test
 using UltraDark
+using MPI
+
+stats_list = [
+              Summary.WallTime,
+              Summary.SimulationTime,
+              Summary.ScaleFactor,
+              Summary.TimeStep,
+              Summary.MeanDensity,
+              Summary.MaxDensity,
+              Summary.RmsDensityContrast,
+              Summary.TotalMass,
+             ]
 
 sim_time = 0.0
 a = 1.
 Δt = 1e-1
-g = Grids(1.0, 8)
 constants = nothing
 
-for s in [
-          Summary.WallTime,
-          Summary.SimulationTime,
-          Summary.ScaleFactor,
-          Summary.TimeStep,
-          Summary.MeanDensity,
-          Summary.MaxDensity,
-          Summary.RmsDensityContrast,
-          Summary.TotalMass,
-         ]
+grids = Grids(1.0, 8)
+pencilgrids = PencilGrids(1.0, 8)
 
-    s(sim_time, a, Δt, g, constants)
+for g in [grids, pencilgrids]
+    g.ψx .= 1.
+    @. g.ρx = abs2(g.ψx)
+end
+
+for s in stats_list
+    stat_grids = s(sim_time, a, Δt, grids, constants)
+
+    local_stat_pencilgrids = s(sim_time, a, Δt, pencilgrids, constants)
+    global_stat_pencilgrids = MPI.Reduce(local_stat_pencilgrids, Summary.pool_summarystat, 0, pencilgrids.MPI_COMM)
+
+    if s !== Summary.WallTime
+        @assert stat_grids == global_stat_pencilgrids
+    end
 end


### PR DESCRIPTION
Expand the tests of summaries to include PencilGrids.  This isn't as
comprehensive as it should be, because CI only uses one MPI process, but
better than nothing.