### PR TITLE
simulate -> simulate!

### DIFF
--- a/examples/2d.ipynb
+++ b/examples/2d.ipynb
@@ -361,7 +361,7 @@
     }
    ],
    "source": [
-    "@time simulate(grids, options, output_config)"
+    "@time simulate!(grids, options, output_config)"
    ]
   },
   {

--- a/examples/soliton_velocity.jl
+++ b/examples/soliton_velocity.jl
@@ -40,7 +40,7 @@ function run_sim()
     add_soliton(grids, mass, position0, velocity, phase, t0)
     @info "Initialized" MPI.Comm_rank(comm)
 
-    simulate(grids, options, output_config) == nothing
+    simulate!(grids, options, output_config) == nothing
     @info "Simulation complete" MPI.Comm_rank(comm)
 
 end

--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -7,7 +7,7 @@ using PencilFFTs, MPI
 
 using FFTW
 
-export simulate
+export simulate!
 export Grids, PencilGrids
 export dV
 export Config, SimulationConfig, constant_scale_factor, TimeStepOptions
@@ -199,7 +199,7 @@ function evolve_to!(t_start, t_end, grids, output_config, sim_config; constants 
     t
 end
 
-function simulate(grids, sim_config, output_config::OutputConfig; constants = nothing)
+function simulate!(grids, sim_config, output_config::OutputConfig; constants = nothing)
 
     # Setup output
     mkpath(output_config.directory)

--- a/test/phase_gradient.jl
+++ b/test/phase_gradient.jl
@@ -85,7 +85,7 @@ end
     options = UltraDark.Config.SimulationConfig()
     output_config = OutputConfig(mktempdir(), [1, 2])
 
-    @test_throws "Phase gradient is too large to start" simulate(
+    @test_throws "Phase gradient is too large to start" simulate!(
         grids,
         options,
         output_config,

--- a/test/sims/full.jl
+++ b/test/sims/full.jl
@@ -14,5 +14,5 @@ options = Config.SimulationConfig()
 for grid_type in [Grids, PencilGrids]
     grids = grid_type(1.0, 16)
     grids.ψx .= (grids.x .^ 2 .+ grids.y .^ 2 .+ grids.z .^ 2) .^ 0.5 ./ 1e9 # Set ψx to something non-zero
-    @test simulate(grids, options, output_config) == nothing
+    @test simulate!(grids, options, output_config) == nothing
 end

--- a/test/sims/soliton_static.jl
+++ b/test/sims/soliton_static.jl
@@ -28,7 +28,7 @@ for grid_type in [Grids, PencilGrids]
 
     add_soliton(grids, mass, position, velocity, phase, t0)
 
-    @test simulate(grids, options, output_config) == nothing
+    @test simulate!(grids, options, output_config) == nothing
 end
 
 # for grid_type in [Grids, PencilGrids]


### PR DESCRIPTION
Conventionally, julia functions that mutate their input have names that
end in `!`.  This was not the case for `simulate`, which mutates the
whole state.  Rename it.

BREAKING CHANGE: simulate -> simulate!