### PR TITLE
fix: Too much overloading of angular momentum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UltraDark"
 uuid = "1c8d022d-dfc0-4b41-80ab-3fc7e88cdfea"
 authors = ["Nathan Musoke <n.musoke@auckland.ac.nz>"]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/pencil_grids.jl
+++ b/src/pencil_grids.jl
@@ -310,7 +310,7 @@ function PencilGrids(length_tuple, resol_tuple::Tuple{Int,Int,Int})::PencilGrids
     )
 end
 
-function angular_momentum_density(grids, ψx, ρx)
+function angular_momentum_density(grids::PencilGrids, ψx, ρx)
 
     angular_momentum = zeros(3, size(ρx)...)
 


### PR DESCRIPTION
Accidentally left the type signature off of the overloaded definition of angular momentum in 92abcb2b251f12deea24134066c2f597415ee407. Fix this.