### PR TITLE
fix: outer_step! call at end of loop missed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UltraDark"
 uuid = "1c8d022d-dfc0-4b41-80ab-3fc7e88cdfea"
 authors = ["Nathan Musoke <n.musoke@auckland.ac.nz>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -166,6 +166,10 @@ function take_steps!(grids, t_start, Δt, n, output_config, a, constants, extern
     end
 
     outer_step!(Δt / 2, grids, constants)
+    for s in external_states
+        outer_step!(Δt / 2, grids, constants, s; a = a(t))
+    end
+
     t += Δt / 2
 
     t


### PR DESCRIPTION
The symmetrized split step method combines most calls to `outer_step!` with half a time step into full time steps.  However, an extra half step has to be taken each time the time step is updated. This is missing for the external states.

With default settings, this results in an approximately 5% error.

Add it in.