### PR TITLE
feat: Write list of output times to disc

### DIFF
--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -228,6 +228,7 @@ function simulate!(
     mkpath(output_config.directory)
     output_summary_header(output_config)
     output_xyz(grids, output_config)
+    Output.output_output_times(output_config.output_times, output_config)
     Output.output_external_states_headers(external_states, output_config)
 
     t_begin = output_config.output_times[1]

--- a/src/output.jl
+++ b/src/output.jl
@@ -164,6 +164,15 @@ function output_xyz(grids, output_config)
 end
 
 """
+    output_output_times(output_times, output_config)
+
+Output the times corresponding to slices
+"""
+function output_output_times(output_times, output_config)
+    NPZ.npzwrite(joinpath(output_config.directory, "output_times.npy"), output_times)
+end
+
+"""
     output_external_states_headers(external_states, output_config)
 """
 function output_external_states_headers(external_states, output_config)


### PR DESCRIPTION
It is useful to have a list of what times output snapshots correspond to.