### PR TITLE
test: Fix overly strong test in summary

### DIFF
--- a/src/summary.jl
+++ b/src/summary.jl
@@ -150,7 +150,7 @@ julia> t1 = Summary.WallTime();
 
 julia> t2 = Summary.WallTime(0.0, 1.0, 1e-1, Grids(1.0, 16), nothing, ());
 
-julia> t1.date < t2.date
+julia> t1.date <= t2.date
 true
 ```
 """


### PR DESCRIPTION
The doc tests for Summary.WallTime occaisionally fail in CI.  This might be because the two times are generated quickly, so t1 == t2.

Check for t1 <= t2, rather than t1 < t2.