### PR TITLE
fix: Correct scale factor on last half step

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UltraDark"
 uuid = "1c8d022d-dfc0-4b41-80ab-3fc7e88cdfea"
 authors = ["Nathan Musoke <n.musoke@auckland.ac.nz>"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/UltraDark.jl
+++ b/src/UltraDark.jl
@@ -165,7 +165,7 @@ function take_steps!(grids, t_start, Δt, n, output_config, a, constants, extern
         output_summary_row(grids, output_config, t, a(t), Δt, constants, external_states)
     end
 
-    outer_step!(Δt / 2, grids, constants)
+    outer_step!(Δt / 2, grids, constants; a = a(t))
     for s in external_states
         outer_step!(Δt / 2, grids, constants, s; a = a(t))
     end


### PR DESCRIPTION
There is a missing `; a = a(t)` in the argument to `outer_step!` that does the closing half step.  This is never an issue if there is no background expansion.

Add it in.

This should maybe not be an optional argument; it shouldn't be possible to accidentally call with the wrong `a(t)`.