### PR TITLE
chore: dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Use dependabot to keep github actions up to date.

See https://github.com/JuliaCI/PkgTemplates.jl/pull/393

Fixes https://github.com/musoke/UltraDark.jl/issues/137