### PR TITLE
fix(tests): Prevent MPI from breaking doc tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,13 @@ using Test, Documenter
 using SafeTestsets
 using MPI
 
+# Initialise MPI before running any tests.
+# This prevents spurious warnings from breaking doc tests by changing stderr.
+if ~MPI.Initialized()
+    MPI.Init()
+end
+@test MPI.Initialized()
+
 doctest(UltraDark)
 
 @safetestset "grids.jl" begin


### PR DESCRIPTION
Initialization of MPI occasionally results in output warning that features are unavailable, etc.  This is not relevant to the doc tests, but can break them by writing to stderr.

Initialize MPI before running any other tests.

Fixes https://github.com/musoke/UltraDark.jl/issues/71