### PR TITLE
fix: Typo in gravitational energy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UltraDark"
 uuid = "1c8d022d-dfc0-4b41-80ab-3fc7e88cdfea"
 authors = ["Nathan Musoke <n.musoke@auckland.ac.nz>"]
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/grids.jl
+++ b/src/grids.jl
@@ -467,7 +467,7 @@ end
 
 Gravitational energy density of field `psi` in gravitational potential `Phi`
 """
-function E_gravity_density(psi::Number, Phi::Number)
+function E_gravity_density(psi::Number, Phi::Real)::Real
     Phi .* abs2.(psi) / 2.0
 end
 
@@ -478,7 +478,7 @@ end
 Gravitational potential energy
 """
 function E_grav(grids, psi)
-    Folds.mapreduce(E_gravity_density, +, grids.Φx, psi) * dV(grids)
+    Folds.mapreduce(E_gravity_density, +, psi, grids.Φx) * dV(grids)
 end
 
 function E_grav(grids::AbstractGrids)

--- a/test/summary.jl
+++ b/test/summary.jl
@@ -28,7 +28,7 @@ pencilgrids = PencilGrids(1.0, 8)
 external_states = ()
 
 for g in [grids, pencilgrids]
-    g.ψx .= 1.0
+    g.ψx .= 1.0 + im
     @. g.ρx = abs2(g.ψx)
 end
 


### PR DESCRIPTION
9b17f3037c4bb013c1aa714cf51383391314d193
(https://github.com/musoke/UltraDark.jl/pull/152) introduced a bug in the gravitational energy.
The arguments of E_gravity_density are reversed.  This doesn't show up in tests because the psi used is real, so the incorrect energy density can be coerced to be real.

Fix this and update the tests of summaries so that psi is complex.